### PR TITLE
Fix typo in 150-app-service.md

### DIFF
--- a/10-azure-application-arch/150-app-service.md
+++ b/10-azure-application-arch/150-app-service.md
@@ -220,7 +220,7 @@ Use `az webapp log tail` to start live log tracing for an Azure web application.
 az webapp log tail \
   --resource-group $MYPREFIX-rg \
   --name $MYPREFIX-app
-``
+```
 
 Now feel free to run the test battery against the remote application:
 


### PR DESCRIPTION
Add ` to the markdown code to show it properly